### PR TITLE
support integer ip addresses

### DIFF
--- a/lib/maxminddb.rb
+++ b/lib/maxminddb.rb
@@ -150,9 +150,14 @@ module MaxMindDB
     end
 
     def addr_from_ip(ip)
-      addr = IPAddr.new(ip)
-      addr = addr.ipv4_compat if addr.ipv4?
-      addr.to_i
+      klass = ip.class
+      if klass == Fixnum || klass == Bignum
+        ip
+      else
+        addr = IPAddr.new(ip)
+        addr = addr.ipv4_compat if addr.ipv4?
+        addr.to_i
+      end
     end
   end
 end

--- a/spec/maxminddb_spec.rb
+++ b/spec/maxminddb_spec.rb
@@ -30,6 +30,22 @@ describe MaxMindDB do
     it 'returns US as the country iso code' do
       expect(country_db.lookup(ip).country.iso_code).to eq('US')
     end
+
+    context 'as a Fixnum' do
+      let(:integer_ip) { IPAddr.new(ip).to_i }
+
+      it 'returns a MaxMindDB::Result' do
+        expect(city_db.lookup(integer_ip)).to be_kind_of(MaxMindDB::Result)
+      end
+
+      it 'returns Mountain View as the English name' do
+        expect(city_db.lookup(integer_ip).city.name).to eq('Mountain View')
+      end
+
+      it 'returns United States as the English country name' do
+        expect(country_db.lookup(integer_ip).country.name).to eq('United States')
+      end
+    end
   end
 
   context 'for the ip 2001:708:510:8:9a6:442c:f8e0:7133' do
@@ -41,6 +57,14 @@ describe MaxMindDB do
 
     it 'returns LV as the country iso code' do
       expect(country_db.lookup(ip).country.iso_code).to eq('LU')
+    end
+
+    context 'as an integer' do
+      let(:integer_ip) { IPAddr.new(ip).to_i }
+
+      it 'returns LV as the country iso code' do
+        expect(country_db.lookup(integer_ip).country.iso_code).to eq('LU')
+      end
     end
   end
 


### PR DESCRIPTION
I already store ip addresses in my database as integers. I would like to be able to do geocoding on these ip addresses without the intermediate step of first converting them to strings. This is good both for code simplicity and performance.

Separate issue: I ran `rake ensure_maxmind_files` prior to running specs. The database files I fetched contained the new country code you see in c47cd21c9965a25fe47a21fa5b27cd42385d5c17. I included the change in this PR so that the test suite would be 100% passing.
