### PR TITLE
Add accessor for represented_country to Result

### DIFF
--- a/lib/maxminddb/result.rb
+++ b/lib/maxminddb/result.rb
@@ -40,6 +40,10 @@ module MaxMindDB
       @_registered_country ||= NamedLocation.new(raw['registered_country'])
     end
 
+    def represented_country
+      @_represented_country ||= NamedLocation.new(raw['represented_country'])
+    end
+
     def subdivisions
       @_subdivisions ||= Array(raw['subdivisions']).map { |hash| NamedLocation.new(hash) }
     end

--- a/spec/maxminddb/result_spec.rb
+++ b/spec/maxminddb/result_spec.rb
@@ -32,6 +32,11 @@ describe MaxMindDB::Result do
       "iso_code"=>"US",
       "names"=>{"de"=>"USA", "en"=>"United States", "es"=>"Estados Unidos", "fr"=>"États-Unis", "ja"=>"アメリカ合衆国", "pt-BR"=>"Estados Unidos", "ru"=>"США", "zh-CN"=>"美国"}
     },
+    "represented_country"=>{
+      "geoname_id"=>6252001,
+      "iso_code"=>"US",
+      "names"=>{"de"=>"USA", "en"=>"United States", "es"=>"Estados Unidos", "fr"=>"États-Unis", "ja"=>"アメリカ合衆国", "pt-BR"=>"Estados Unidos", "ru"=>"США", "zh-CN"=>"美国"}
+    },
     "subdivisions"=>[
       {
         "geoname_id"=>5332921,
@@ -183,6 +188,20 @@ describe MaxMindDB::Result do
         expect(MaxMindDB::Result::NamedLocation).to receive(:new).with(raw_result['registered_country'])
 
         result.registered_country
+      end
+    end
+  end
+
+  describe '#represented_country' do
+    context 'with a result' do
+      it 'should be a kind of MaxMindDB::Result::NamedLocation' do
+        expect(result.represented_country).to be_kind_of(MaxMindDB::Result::NamedLocation)
+      end
+
+      it 'should initialize the location with the represented_country attributes' do
+        expect(MaxMindDB::Result::NamedLocation).to receive(:new).with(raw_result['represented_country'])
+
+        result.represented_country
       end
     end
   end


### PR DESCRIPTION
We were using `ret['represented_country']` in version 0.0.2, and it appears that there is no accessor in later versions of the gem. This adds the accessor, so we can consistently use `ret.country`/`ret.registered_country`/`ret.represented_country`.

Fixes #10 
