### PR TITLE
Add traits result type.

### DIFF
--- a/lib/maxminddb/result.rb
+++ b/lib/maxminddb/result.rb
@@ -1,6 +1,7 @@
 require_relative 'result/location'
 require_relative 'result/named_location'
 require_relative 'result/postal'
+require_relative 'result/traits'
 
 module MaxMindDB
   class Result
@@ -46,6 +47,10 @@ module MaxMindDB
 
     def subdivisions
       @_subdivisions ||= Array(raw['subdivisions']).map { |hash| NamedLocation.new(hash) }
+    end
+
+    def traits
+      @_traits ||= Traits.new(raw['traits'])
     end
 
     private

--- a/lib/maxminddb/result/traits.rb
+++ b/lib/maxminddb/result/traits.rb
@@ -1,0 +1,21 @@
+module MaxMindDB
+  class Result
+    class Traits
+      def initialize(raw)
+        @raw = raw || {}
+      end
+
+      def is_anonymous_proxy
+        raw['is_anonymous_proxy']
+      end
+
+      def is_satellite_provider
+        raw['is_satellite_provider']
+      end
+
+      private
+
+      attr_reader :raw
+    end
+  end
+end

--- a/spec/maxminddb/result/trait_spec.rb
+++ b/spec/maxminddb/result/trait_spec.rb
@@ -1,0 +1,40 @@
+require 'maxminddb'
+
+describe MaxMindDB::Result::Traits do
+  subject(:result) { described_class.new(raw_result) }
+
+  context "with an is_anonymous_proxy result" do
+    let(:raw_result) { {
+      "is_anonymous_proxy"=>true
+    } }
+
+    its(:is_anonymous_proxy) { should eq(true) }
+    its(:is_satellite_provider) { should eq(nil) }
+  end
+
+  context "with an is_satellite_provider result" do
+    let(:raw_result) { {
+      "is_satellite_provider"=>true
+    } }
+
+    its(:is_anonymous_proxy) { should eq(nil) }
+    its(:is_satellite_provider) { should eq(true) }
+  end
+
+  context "with an all traits result" do
+    let(:raw_result) { {
+      "is_anonymous_proxy"=>true,
+      "is_satellite_provider"=>true
+    } }
+
+    its(:is_anonymous_proxy) { should eq(true) }
+    its(:is_satellite_provider) { should eq(true) }
+  end
+
+  context "without a result" do
+    let(:raw_result) { nil }
+
+    its(:is_anonymous_proxy) { should eq(nil) }
+    its(:is_satellite_provider) { should eq(nil) }
+  end
+end

--- a/spec/maxminddb/result_spec.rb
+++ b/spec/maxminddb/result_spec.rb
@@ -37,6 +37,9 @@ describe MaxMindDB::Result do
       "iso_code"=>"US",
       "names"=>{"de"=>"USA", "en"=>"United States", "es"=>"Estados Unidos", "fr"=>"États-Unis", "ja"=>"アメリカ合衆国", "pt-BR"=>"Estados Unidos", "ru"=>"США", "zh-CN"=>"美国"}
     },
+    "traits"=>{
+      "is_satellite_provider"=>true
+    },
     "subdivisions"=>[
       {
         "geoname_id"=>5332921,
@@ -236,6 +239,28 @@ describe MaxMindDB::Result do
 
       it 'should be empty' do
         expect(result.subdivisions).to be_empty
+      end
+    end
+  end
+
+  describe '#traits' do
+    context 'with a result' do
+      it 'should return a kind of MaxMindDB::Result::Traits' do
+        expect(result.traits).to be_kind_of(MaxMindDB::Result::Traits)
+      end
+
+      it 'should initialize the object with the traits attributes' do
+        expect(MaxMindDB::Result::Traits).to receive(:new).with(raw_result['traits'])
+
+        result.traits
+      end
+    end
+
+    context "without a result" do
+      let(:raw_result) { nil }
+
+      it 'should be a kind of MaxMindDB::Result::Traits' do
+        expect(result.traits).to be_kind_of(MaxMindDB::Result::Traits)
       end
     end
   end

--- a/spec/maxminddb_spec.rb
+++ b/spec/maxminddb_spec.rb
@@ -23,6 +23,10 @@ describe MaxMindDB do
       expect(city_db.lookup(ip).location.longitude).to eq(-122.0574)
     end
 
+    it 'returns nil for is_anonymous_proxy' do
+      expect(city_db.lookup(ip).traits.is_anonymous_proxy).to eq(nil)
+    end
+
     it 'returns United States as the English country name' do
       expect(country_db.lookup(ip).country.name).to eq('United States')
     end
@@ -97,6 +101,14 @@ describe MaxMindDB do
       it "returns #{iso} as the country iso code" do
         expect(country_db.lookup(ip).country.iso_code).to eq(iso)
       end
+    end
+  end
+
+  context 'test boolean data' do
+    let(:ip) { '41.194.0.1' }
+
+    it 'returns true for the is_satellite_provider trait' do
+      expect(city_db.lookup(ip).traits.is_satellite_provider).to eq(true)
     end
   end
 end


### PR DESCRIPTION
This adds a traits result type with tests since I was missing the anonymous proxy determination after upgrading to version 2 of the db.