### PR TITLE
Support for Connection Type DB

### DIFF
--- a/lib/maxminddb/result.rb
+++ b/lib/maxminddb/result.rb
@@ -53,6 +53,10 @@ module MaxMindDB
       @_traits ||= Traits.new(raw['traits'])
     end
 
+    def connection_type
+      @_connection_type ||= raw['connection_type']
+    end
+
     def to_hash
       @_to_hash ||= raw.clone
     end

--- a/spec/maxminddb/result_spec.rb
+++ b/spec/maxminddb/result_spec.rb
@@ -46,7 +46,8 @@ describe MaxMindDB::Result do
         "iso_code"=>"CA",
         "names"=>{"de"=>"Kalifornien", "en"=>"California", "es"=>"California", "fr"=>"Californie", "ja"=>"カリフォルニア州", "pt-BR"=>"Califórnia", "ru"=>"Калифорния", "zh-CN"=>"加利福尼亚州"}
       }
-    ]
+    ],
+    "connection_type"=>"Dialup"
   } }
 
   describe '#[]' do
@@ -271,6 +272,22 @@ describe MaxMindDB::Result do
 
       it 'should be a kind of MaxMindDB::Result::Traits' do
         expect(result.traits).to be_kind_of(MaxMindDB::Result::Traits)
+      end
+    end
+  end
+
+  describe '#connection_type' do
+    context 'with a result' do
+      it 'should return a String representation of connection type' do
+        expect(result.connection_type).to eq("Dialup")
+      end
+    end
+
+    context "without a result" do
+      let(:raw_result) { nil }
+
+      it 'should be nil' do
+        expect(result.connection_type).to be_nil
       end
     end
   end


### PR DESCRIPTION
Maxmind now offers connection type database based
on the user IP address. This change gives a convenient
way to use it.

See: https://www.maxmind.com/en/geoip2-connection-type-database