### PR TITLE
Fix decoding of booleans.

### DIFF
--- a/lib/maxminddb.rb
+++ b/lib/maxminddb.rb
@@ -134,7 +134,7 @@ module MaxMindDB
         when 13 # end marker
           val = nil
         when 14 # boolean
-          val = size ? true : false
+          val = (size != 0)
         when 15 # float
           val = @data[pos + base_pos, size].unpack('g')[0]
           pos += size

--- a/spec/maxminddb_spec.rb
+++ b/spec/maxminddb_spec.rb
@@ -110,6 +110,9 @@ describe MaxMindDB do
     it 'returns true for the is_satellite_provider trait' do
       expect(city_db.lookup(ip).traits.is_satellite_provider).to eq(true)
     end
+
+    # There are no false booleans in the database that we can test.
+    # False values are simply omitted.
   end
 end
 


### PR DESCRIPTION
Fix decoding of booleans.

Note that prior to this patch all booleans have been decoded "correctly" since currently all booleans are decoded as true but there are no false booleans in the database.