### PR TITLE
Removed Fixnum and Bignum deprecation warnings

### DIFF
--- a/lib/maxminddb.rb
+++ b/lib/maxminddb.rb
@@ -159,13 +159,13 @@ module MaxMindDB
 
     def addr_from_ip(ip)
       klass = ip.class
-      if klass == Fixnum || klass == Bignum
-        ip
-      else
-        addr = IPAddr.new(ip)
-        addr = addr.ipv4_compat if addr.ipv4?
-        addr.to_i
-      end
+
+      return ip if RUBY_VERSION.to_f < 2.4 && (klass == Fixnum || klass == Bignum)
+      return ip if RUBY_VERSION.to_f >= 2.4 && klass == Integer
+
+      addr = IPAddr.new(ip)
+      addr = addr.ipv4_compat if addr.ipv4?
+      addr.to_i
     end
   end
 end

--- a/spec/maxminddb_spec.rb
+++ b/spec/maxminddb_spec.rb
@@ -36,7 +36,7 @@ describe MaxMindDB do
       expect(country_db.lookup(ip).country.iso_code).to eq('US')
     end
 
-    context 'as a Fixnum' do
+    context 'as a Integer' do
       let(:integer_ip) { IPAddr.new(ip).to_i }
 
       it 'returns a MaxMindDB::Result' do


### PR DESCRIPTION
I've added a ruby version check to use the new Integer class instead of Fixnum and Bignum classes. This will remove deprecation warnings in Ruby >= 2.4.