### PR TITLE
Expose accuracy_radius in Location data

### DIFF
--- a/lib/maxminddb/result/location.rb
+++ b/lib/maxminddb/result/location.rb
@@ -20,6 +20,10 @@ module MaxMindDB
       def time_zone
         raw['time_zone']
       end
+      
+      def accuracy_radius
+        raw['accuracy_radius']
+      end
 
       private
 

--- a/spec/maxminddb/result/location_spec.rb
+++ b/spec/maxminddb/result/location_spec.rb
@@ -9,13 +9,15 @@ describe MaxMindDB::Result::Location do
       "latitude"=>37.419200000000004,
       "longitude"=>-122.0574,
       "metro_code"=>"807",
-      "time_zone"=>"America/Los_Angeles"
+      "time_zone"=>"America/Los_Angeles",
+      "accuracy_radius"=>1000
     } }
 
     its(:latitude) { should eq(37.419200000000004) }
     its(:longitude) { should eq(-122.0574) }
     its(:metro_code) { should eq("807") }
     its(:time_zone) { should eq("America/Los_Angeles") }
+    its(:accuracy_radius) { should eq(1000) }
   end
 
   context "without a result" do
@@ -25,5 +27,6 @@ describe MaxMindDB::Result::Location do
     its(:longitude) { should be_nil }
     its(:metro_code) { should be_nil }
     its(:time_zone) { should be_nil }
+    its(:accuracy_radius) { should be_nil }
   end
 end


### PR DESCRIPTION
In the latest MaxMind Geolite City database (https://dev.maxmind.com/geoip/geoip2/geolite2/), it has an `accuracy_radius` data that is currently not being exposed.

This PR adds the `accuracy_radius` data to the `MaxMindDB::Result::Location` class, and also updated the specs for the new data.