### PR TITLE
Implement #most_specific method for result subdivisions

### DIFF
--- a/lib/maxminddb/result.rb
+++ b/lib/maxminddb/result.rb
@@ -1,6 +1,7 @@
 require_relative 'result/location'
 require_relative 'result/named_location'
 require_relative 'result/postal'
+require_relative 'result/subdivisions'
 require_relative 'result/traits'
 
 module MaxMindDB
@@ -46,7 +47,7 @@ module MaxMindDB
     end
 
     def subdivisions
-      @_subdivisions ||= Array(raw['subdivisions']).map { |hash| NamedLocation.new(hash) }
+      @_subdivisions ||= Subdivisions.new(raw['subdivisions'])
     end
 
     def traits

--- a/lib/maxminddb/result/location.rb
+++ b/lib/maxminddb/result/location.rb
@@ -20,7 +20,7 @@ module MaxMindDB
       def time_zone
         raw['time_zone']
       end
-      
+
       def accuracy_radius
         raw['accuracy_radius']
       end

--- a/lib/maxminddb/result/subdivisions.rb
+++ b/lib/maxminddb/result/subdivisions.rb
@@ -1,0 +1,17 @@
+module MaxMindDB
+  class Result
+    class Subdivisions < Array
+      def initialize(raw)
+        super((raw || []).map { |hash| NamedLocation.new(hash) })
+      end
+
+      def most_specific
+        last || NamedLocation.new({})
+      end
+
+      def inspect
+        "#<MaxMindDB::Result::Subdivisions: #{super}>"
+      end
+    end
+  end
+end

--- a/spec/maxminddb/result/subdivisions_spec.rb
+++ b/spec/maxminddb/result/subdivisions_spec.rb
@@ -1,0 +1,65 @@
+# -*- encoding: utf-8 -*-
+require 'maxminddb'
+
+describe MaxMindDB::Result::Subdivisions do
+  subject(:subdivisions) { described_class.new(raw_subdivisions) }
+
+  context "with multiple subdivisions" do
+    let(:raw_subdivisions) { [{
+      "geoname_id"=>5037779,
+      "iso_code"=>"MN",
+      "names"=>{"en"=>"Minnesota"}
+    }, {
+      "geoname_id"=>123,
+      "iso_code"=>"HP",
+      "names"=>{"en"=>"Hennepin"}
+    }] }
+
+    it 'should be a kind of Array' do
+      expect(subdivisions).to be_kind_of(Array)
+    end
+
+    it 'should return as many items as there are subdivisions passed in' do
+      expect(subdivisions.length).to eq(raw_subdivisions.length)
+    end
+
+    it 'should contain only MaxMindDB::Result::NamedLocation' do
+      expect(subdivisions.all? { |r| r.kind_of?(MaxMindDB::Result::NamedLocation)}).to be_truthy
+    end
+
+    describe "most_specific" do
+      it 'should be a kind of MaxMindDB::Result::NamedLocation' do
+        expect(subdivisions.most_specific).to be_kind_of(MaxMindDB::Result::NamedLocation)
+      end
+
+      it 'should eq "Hennepin" subdivision' do
+        expect(subdivisions.most_specific.name).to eq("Hennepin")
+      end
+    end
+  end
+
+  context "without a result" do
+    let(:raw_subdivisions) { nil }
+
+    it 'should be a kind of Array' do
+      expect(subdivisions).to be_kind_of(Array)
+    end
+
+    it 'should be empty' do
+      expect(subdivisions.length).to eq(0)
+    end
+
+    describe "most_specific" do
+      it 'should be a kind of MaxMindDB::Result::NamedLocation' do
+        expect(subdivisions.most_specific).to be_kind_of(MaxMindDB::Result::NamedLocation)
+      end
+
+      it 'should be an empty MaxMindDB::Result::NamedLocation' do
+        expect(subdivisions.most_specific.code).to eq(nil)
+        expect(subdivisions.most_specific.geoname_id).to eq(nil)
+        expect(subdivisions.most_specific.iso_code).to eq(nil)
+        expect(subdivisions.most_specific.name).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds feature parity with the official Python client when accessing subdivisions.

It will return the most specific (last) NamedLocation of the subdivisions array or an "empty" NamedLocation (to be consistent with Python client) if no subdivisions available.

See the official Python library for reference: https://github.com/maxmind/GeoIP2-python/blob/04c8914d6445ed21c1df9bd1476153fd5c76ef36/geoip2/records.py#L444

Happy to return nil instead of an empty NamedLocation, whatever you think is best.