### PR TITLE
Allow the database file reader to be overridden

### DIFF
--- a/lib/maxminddb.rb
+++ b/lib/maxminddb.rb
@@ -4,8 +4,10 @@ require 'ipaddr'
 
 module MaxMindDB
 
-  def self.new(path)
-    Client.new(path)
+  DEFAULT_FILE_READER = proc { |path| File.binread(path) }
+
+  def self.new(path, file_reader=DEFAULT_FILE_READER)
+    Client.new(path, file_reader)
   end
 
   class Client
@@ -16,9 +18,9 @@ module MaxMindDB
 
     attr_reader :metadata
 
-    def initialize(path)
+    def initialize(path, file_reader)
       @path = path
-      @data = File.binread(path)
+      @data = file_reader.call(path)
 
       pos = @data.rindex(METADATA_BEGIN_MARKER)
       raise 'invalid file format' unless pos


### PR DESCRIPTION
Hello! Thanks for your gem, it's great.

We'd like to use your gem, but have some concerns with how much memory it may use when reading from many different databases. It looks like it reads the entire database into memory.

A quick and easy fix for this is to use something like `mmap` to efficiently read the file without having to load it entirely into memory. Luckily, that's actually really easy to do using the `mmap` gem: https://github.com/tenderlove/mmap. It implements the normal `File` API, but using `mmap` under the hood.

The catch is that it adds a dependency on a C extension, which makes this gem no longer a "Pure ruby" solution.

To work around that, I'm proposing a small, backwards compatible change to the API. This PR adds a second argument to the `MaxMindDB.new` constructor, `file_reader`. This argument is a proc that is used to read data from `path`. The default is to use `File.binread`, which is the existing behavior. 

This enables us to pass in a different file reader that uses `mmap`. For example:

```ruby

require 'maxminddb'
require 'mmap'

db = MaxMindDB.new('/path/to/db.mmdb', proc { |p| Mmap.new(p, 'r') })
```

Running the test suite using `mmap` results in ~10x speed up :)

_Existing reader_
```
Finished in 0.80065 seconds (files took 0.28807 seconds to load)
110 examples, 0 failures
```

_Mmap_
```
Finished in 0.05861 seconds (files took 0.17916 seconds to load)
110 examples, 0 failures
```

Let me know what you think!

Cheers