### PR TITLE
Backward Compatible Client Initialize

### DIFF
--- a/lib/maxminddb.rb
+++ b/lib/maxminddb.rb
@@ -18,7 +18,7 @@ module MaxMindDB
 
     attr_reader :metadata
 
-    def initialize(path, file_reader)
+    def initialize(path, file_reader = DEFAULT_FILE_READER)
       @path = path
       @data = file_reader.call(path)
 


### PR DESCRIPTION
By allowing the `file_reader` to fall back to the default. This allows code written to the docs in the README to initialize a client with only the file path.