### PR TITLE
Implement a faster default reader

### DIFF
--- a/lib/maxminddb.rb
+++ b/lib/maxminddb.rb
@@ -1,10 +1,11 @@
 require "maxminddb/version"
 require 'maxminddb/result'
+require 'maxminddb/reader'
 require 'ipaddr'
 
 module MaxMindDB
 
-  DEFAULT_FILE_READER = proc { |path| File.binread(path) }
+  DEFAULT_FILE_READER = proc { |path| MaxMindDB::Reader.new(path) }
 
   def self.new(path, file_reader=DEFAULT_FILE_READER)
     Client.new(path, file_reader)

--- a/lib/maxminddb/reader.rb
+++ b/lib/maxminddb/reader.rb
@@ -1,0 +1,30 @@
+
+module MaxMindDB
+  class Reader
+    METADATA_MAX_SIZE = 128 * 1024
+
+    def initialize(path)
+      @mutex = Mutex.new
+      @file = File.open(path, 'rb')
+    end
+
+    def [](pos, length=1)
+      atomic_read(length, pos)
+    end
+
+    def rindex(search)
+      base = [0, @file.size - METADATA_MAX_SIZE].max
+      tail = atomic_read(METADATA_MAX_SIZE, base)
+      pos = tail.rindex(search)
+      return nil if pos.nil?
+      base + pos
+    end
+
+    def atomic_read(length, pos)
+      @mutex.synchronize do
+        @file.seek(pos)
+        @file.read(length)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello! It's me again!

In pursuit of more performance gains, I wonder if you'd be interested in this modification. In my last PR I made it possible to swap out the file reader implementation. This change adds a faster default reader.

`File.binread` reads the entire file into memory. However, we don't have to do that if we use `seek` and `read`. Also, according to the MaxMindDB spec, the metadata section can only take up to 128kb. This means that we only have to read, at most, 128kb into memory to fully parse the metadata. 

The speedup is not quite as dramatic as using `Mmap`, but it is still significant. 

Running the tests against `master`:
```
Finished in 0.82818 seconds (files took 0.15708 seconds to load)
110 examples, 0 failures
```

Running the tests against this branch:
```
Finished in 0.13147 seconds (files took 0.16954 seconds to load)
110 examples, 0 failures
```

Around a ~6x increase.