### PR TITLE
Make the low-memory file reader opt-in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3
   - 2.4.0
   - 2.5.1
+  - 2.6.0-preview2
   - jruby-19mode
 
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.2
   - 2.3
   - 2.4.0
+  - 2.5.1
   - jruby-19mode
 
 script: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -81,10 +81,23 @@ A MaxMindDB instance doesn't do any write operation after it is created. So we c
 
 maxminddb-docker: https://github.com/samnissen/maxminddb-docker
 
+### File reading strategies
+
+By default, `MaxMinDB.new` will read the entire database into memory. This makes subsequent lookups fast, but can result in a fairly large memory overhead.
+
+If having a low memory overhead is important, you can use the `LowMemoryReader` by passing a `file_reader` argument to `MaxMindDB.new`. For example:
+
+```ruby
+db = MaxMindDB.new('./GeoLite2-City.mmdb', MaxMindDB::LOW_MEMORY_FILE_READER)
+ret = db.lookup('74.125.225.224')
+```
+
+The `LowMemoryReader` will not load the entire database into memory. It's important to note that for Ruby versions lower than `2.5.0`, the `LowMemoryReader` is not process safe. Forking a process after initializing a `MaxMindDB` instance can lead to unexpected results. For Ruby versions >= `2.5.0`, `LowMemoryReader` uses `File.pread` which works safely in forking environments.
+
 ## Contributing
 
-1. Fork it ( http://github.com/yhirose/maxminddb/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+1.  Fork it ( http://github.com/yhirose/maxminddb/fork )
+2.  Create your feature branch (`git checkout -b my-new-feature`)
+3.  Commit your changes (`git commit -am 'Add some feature'`)
+4.  Push to the branch (`git push origin my-new-feature`)
+5.  Create new Pull Request

--- a/lib/maxminddb.rb
+++ b/lib/maxminddb.rb
@@ -5,7 +5,13 @@ require 'ipaddr'
 
 module MaxMindDB
 
-  DEFAULT_FILE_READER = proc { |path| MaxMindDB::Reader.new(path) }
+  # The default reader for MaxMindDB files. Reads the database into memory.
+  # This creates a higher memory overhead, but faster lookup times.
+  DEFAULT_FILE_READER = proc { |path| File.binread(path) }
+
+  # A low memory file reader for MaxMindDB files. Avoids reading the database
+  # into memory. Has a lower memory footprint but slower lookup times.
+  LOW_MEMORY_FILE_READER = proc { |path| MaxMindDB::LowMemoryReader.new(path) }
 
   def self.new(path, file_reader=DEFAULT_FILE_READER)
     Client.new(path, file_reader)

--- a/lib/maxminddb/reader.rb
+++ b/lib/maxminddb/reader.rb
@@ -1,6 +1,6 @@
 
 module MaxMindDB
-  class Reader
+  class LowMemoryReader
     METADATA_MAX_SIZE = 128 * 1024
 
     def initialize(path)

--- a/spec/maxminddb_spec.rb
+++ b/spec/maxminddb_spec.rb
@@ -1,215 +1,224 @@
 require 'maxminddb'
 
 describe MaxMindDB do
-  let(:city_db) { MaxMindDB.new('spec/cache/GeoLite2-City.mmdb') }
-  let(:country_db) { MaxMindDB.new('spec/cache/GeoLite2-Country.mmdb') }
-  let(:rec32_db) { MaxMindDB.new('spec/data/32bit_record_data.mmdb') }
+  [
+    ['default file reader', MaxMindDB::DEFAULT_FILE_READER],
+    ['low memory file reader', MaxMindDB::LOW_MEMORY_FILE_READER],
+  ].each do |file_reader|
+    description, reader = file_reader
 
-  context 'for the ip 74.125.225.224' do
-    let(:ip) { '74.125.225.224' }
+    describe description do
+      let(:city_db) { MaxMindDB.new('spec/cache/GeoLite2-City.mmdb', reader) }
+      let(:country_db) { MaxMindDB.new('spec/cache/GeoLite2-Country.mmdb', reader) }
+      let(:rec32_db) { MaxMindDB.new('spec/data/32bit_record_data.mmdb', reader) }
 
-    it 'returns a MaxMindDB::Result' do
-      expect(city_db.lookup(ip)).to be_kind_of(MaxMindDB::Result)
-    end
+      context 'for the ip 74.125.225.224' do
+        let(:ip) { '74.125.225.224' }
 
-    it 'finds data' do
-      expect(city_db.lookup(ip)).to be_found
-    end
+        it 'returns a MaxMindDB::Result' do
+          expect(city_db.lookup(ip)).to be_kind_of(MaxMindDB::Result)
+        end
 
-    it 'returns Mountain View as the English name' do
-      expect(city_db.lookup(ip).city.name).to eq('Alameda')
-    end
+        it 'finds data' do
+          expect(city_db.lookup(ip)).to be_found
+        end
 
-    it 'returns -122.0574 as the longitude' do
-      expect(city_db.lookup(ip).location.longitude).to eq(-122.2788)
-    end
+        it 'returns Mountain View as the English name' do
+          expect(city_db.lookup(ip).city.name).to eq('Alameda')
+        end
 
-    it 'returns nil for is_anonymous_proxy' do
-      expect(city_db.lookup(ip).traits.is_anonymous_proxy).to eq(nil)
-    end
+        it 'returns -122.0574 as the longitude' do
+          expect(city_db.lookup(ip).location.longitude).to eq(-122.2788)
+        end
 
-    it 'returns United States as the English country name' do
-      expect(country_db.lookup(ip).country.name).to eq('United States')
-    end
+        it 'returns nil for is_anonymous_proxy' do
+          expect(city_db.lookup(ip).traits.is_anonymous_proxy).to eq(nil)
+        end
 
-    it 'returns false for the is_in_european_union' do
-      expect(country_db.lookup(ip).country.is_in_european_union).to eq(nil)
-    end
+        it 'returns United States as the English country name' do
+          expect(country_db.lookup(ip).country.name).to eq('United States')
+        end
 
-    it 'returns US as the country iso code' do
-      expect(country_db.lookup(ip).country.iso_code).to eq('US')
-    end
+        it 'returns false for the is_in_european_union' do
+          expect(country_db.lookup(ip).country.is_in_european_union).to eq(nil)
+        end
 
-    context 'as a Integer' do
-      let(:integer_ip) { IPAddr.new(ip).to_i }
+        it 'returns US as the country iso code' do
+          expect(country_db.lookup(ip).country.iso_code).to eq('US')
+        end
 
-      it 'returns a MaxMindDB::Result' do
-        expect(city_db.lookup(integer_ip)).to be_kind_of(MaxMindDB::Result)
+        context 'as a Integer' do
+          let(:integer_ip) { IPAddr.new(ip).to_i }
+
+          it 'returns a MaxMindDB::Result' do
+            expect(city_db.lookup(integer_ip)).to be_kind_of(MaxMindDB::Result)
+          end
+
+          it 'returns Mountain View as the English name' do
+            expect(city_db.lookup(integer_ip).city.name).to eq('Alameda')
+          end
+
+          it 'returns United States as the English country name' do
+            expect(country_db.lookup(integer_ip).country.name).to eq('United States')
+          end
+        end
       end
 
-      it 'returns Mountain View as the English name' do
-        expect(city_db.lookup(integer_ip).city.name).to eq('Alameda')
+      context 'for the ip 2001:708:510:8:9a6:442c:f8e0:7133' do
+        let(:ip) { '2001:708:510:8:9a6:442c:f8e0:7133' }
+
+        it 'finds data' do
+          expect(city_db.lookup(ip)).to be_found
+        end
+
+        it 'returns true for the is_in_european_union' do
+          expect(country_db.lookup(ip).country.is_in_european_union).to eq(true)
+        end
+
+        it 'returns FI as the country iso code' do
+          expect(country_db.lookup(ip).country.iso_code).to eq('FI')
+        end
+
+        context 'as an integer' do
+          let(:integer_ip) { IPAddr.new(ip).to_i }
+
+          it 'returns FI as the country iso code' do
+            expect(country_db.lookup(integer_ip).country.iso_code).to eq('FI')
+          end
+        end
       end
 
-      it 'returns United States as the English country name' do
-        expect(country_db.lookup(integer_ip).country.name).to eq('United States')
-      end
-    end
-  end
+      context 'for a Canadian ipv6' do
+        let(:ip) { '2607:5300:60:72ba::' }
 
-  context 'for the ip 2001:708:510:8:9a6:442c:f8e0:7133' do
-    let(:ip) { '2001:708:510:8:9a6:442c:f8e0:7133' }
+        it 'finds data' do
+          expect(city_db.lookup(ip)).to be_found
+        end
 
-    it 'finds data' do
-      expect(city_db.lookup(ip)).to be_found
-    end
+        it 'returns true for the is_in_european_union' do
+          expect(country_db.lookup(ip).country.is_in_european_union).to be_falsey
+        end
 
-    it 'returns true for the is_in_european_union' do
-      expect(country_db.lookup(ip).country.is_in_european_union).to eq(true)
-    end
-
-    it 'returns FI as the country iso code' do
-      expect(country_db.lookup(ip).country.iso_code).to eq('FI')
-    end
-
-    context 'as an integer' do
-      let(:integer_ip) { IPAddr.new(ip).to_i }
-
-      it 'returns FI as the country iso code' do
-        expect(country_db.lookup(integer_ip).country.iso_code).to eq('FI')
-      end
-    end
-  end
-
-  context 'for a Canadian ipv6' do
-    let(:ip) { '2607:5300:60:72ba::' }
-
-    it 'finds data' do
-      expect(city_db.lookup(ip)).to be_found
-    end
-
-    it 'returns true for the is_in_european_union' do
-      expect(country_db.lookup(ip).country.is_in_european_union).to be_falsey
-    end
-
-    it 'returns CA as the country iso code' do
-      expect(country_db.lookup(ip).country.iso_code).to eq('CA')
-    end
-  end
-
-  context 'for a German IPv6' do
-    let(:ip) { '2a01:488:66:1000:2ea3:495e::1' }
-
-    it 'finds data' do
-      expect(city_db.lookup(ip)).to be_found
-    end
-
-    it 'returns true for the is_in_european_union' do
-      expect(country_db.lookup(ip).country.is_in_european_union).to eq(true)
-    end
-
-    it 'returns DE as the country iso code' do
-      expect(country_db.lookup(ip).country.iso_code).to eq('DE')
-    end
-  end
-
-  context 'for the ip 127.0.0.1' do
-    let(:ip) { '127.0.0.1' }
-
-    it 'returns a MaxMindDB::Result' do
-      expect(city_db.lookup(ip)).to be_kind_of(MaxMindDB::Result)
-    end
-
-    it "doesn't find data" do
-      expect(city_db.lookup(ip)).to_not be_found
-    end
-  end
-
-  context 'for local ip addresses' do
-    let(:ip) { '127.0.0.1' }
-
-    context 'for city_db' do
-      before do
-        city_db.local_ip_alias = '74.125.225.224'
+        it 'returns CA as the country iso code' do
+          expect(country_db.lookup(ip).country.iso_code).to eq('CA')
+        end
       end
 
-      it 'returns a MaxMindDB::Result' do
-        expect(city_db.lookup(ip)).to be_kind_of(MaxMindDB::Result)
+      context 'for a German IPv6' do
+        let(:ip) { '2a01:488:66:1000:2ea3:495e::1' }
+
+        it 'finds data' do
+          expect(city_db.lookup(ip)).to be_found
+        end
+
+        it 'returns true for the is_in_european_union' do
+          expect(country_db.lookup(ip).country.is_in_european_union).to eq(true)
+        end
+
+        it 'returns DE as the country iso code' do
+          expect(country_db.lookup(ip).country.iso_code).to eq('DE')
+        end
       end
 
-      it 'finds data' do
-        expect(city_db.lookup(ip)).to be_found
+      context 'for the ip 127.0.0.1' do
+        let(:ip) { '127.0.0.1' }
+
+        it 'returns a MaxMindDB::Result' do
+          expect(city_db.lookup(ip)).to be_kind_of(MaxMindDB::Result)
+        end
+
+        it "doesn't find data" do
+          expect(city_db.lookup(ip)).to_not be_found
+        end
       end
 
-      it 'returns Mountain View as the English name' do
-        expect(city_db.lookup(ip).city.name).to eq('Alameda')
+      context 'for local ip addresses' do
+        let(:ip) { '127.0.0.1' }
+
+        context 'for city_db' do
+          before do
+            city_db.local_ip_alias = '74.125.225.224'
+          end
+
+          it 'returns a MaxMindDB::Result' do
+            expect(city_db.lookup(ip)).to be_kind_of(MaxMindDB::Result)
+          end
+
+          it 'finds data' do
+            expect(city_db.lookup(ip)).to be_found
+          end
+
+          it 'returns Mountain View as the English name' do
+            expect(city_db.lookup(ip).city.name).to eq('Alameda')
+          end
+
+          it 'returns -122.0574 as the longitude' do
+            expect(city_db.lookup(ip).location.longitude).to eq(-122.2788)
+          end
+
+          it 'returns nil for is_anonymous_proxy' do
+            expect(city_db.lookup(ip).traits.is_anonymous_proxy).to eq(nil)
+          end
+        end
+
+        context 'for country_db' do
+          before do
+            country_db.local_ip_alias = '74.125.225.224'
+          end
+
+          it 'returns United States as the English country name' do
+            expect(country_db.lookup(ip).country.name).to eq('United States')
+          end
+
+          it 'returns false for the is_in_european_union' do
+            expect(country_db.lookup(ip).country.is_in_european_union).to eq(nil)
+          end
+
+          it 'returns US as the country iso code' do
+            expect(country_db.lookup(ip).country.iso_code).to eq('US')
+          end
+        end
       end
 
-      it 'returns -122.0574 as the longitude' do
-        expect(city_db.lookup(ip).location.longitude).to eq(-122.2788)
+      context 'for 32bit record data' do
+        let(:ip) { '1.0.16.1' }
+
+        it 'finds data' do
+          expect(rec32_db.lookup(ip)).to be_found
+        end
       end
 
-      it 'returns nil for is_anonymous_proxy' do
-        expect(city_db.lookup(ip).traits.is_anonymous_proxy).to eq(nil)
+      context 'test ips' do
+        [
+          ['185.23.124.1', 'SA'],
+          ['178.72.254.1', 'CZ'],
+          ['95.153.177.210', 'RU'],
+          ['200.148.105.119', 'BR'],
+          ['195.59.71.43', 'GB'],
+          ['179.175.47.87', 'BR'],
+          ['202.67.40.50', 'ID'],
+        ].each do |ip, iso|
+          it 'returns a MaxMindDB::Result' do
+            expect(city_db.lookup(ip)).to be_kind_of(MaxMindDB::Result)
+          end
+
+          it "returns #{iso} as the country iso code" do
+            expect(country_db.lookup(ip).country.iso_code).to eq(iso)
+          end
+        end
+      end
+
+      context 'test boolean data' do
+        let(:ip) { '41.194.0.1' }
+
+        it 'returns true for the is_satellite_provider trait' do
+          expect(city_db.lookup(ip).traits.is_satellite_provider).to eq(nil)
+        end
+
+        # There are no false booleans in the database that we can test.
+        # False values are simply omitted.
       end
     end
-
-    context 'for country_db' do
-      before do
-        country_db.local_ip_alias = '74.125.225.224'
-      end
-
-      it 'returns United States as the English country name' do
-        expect(country_db.lookup(ip).country.name).to eq('United States')
-      end
-
-      it 'returns false for the is_in_european_union' do
-        expect(country_db.lookup(ip).country.is_in_european_union).to eq(nil)
-      end
-
-      it 'returns US as the country iso code' do
-        expect(country_db.lookup(ip).country.iso_code).to eq('US')
-      end
-    end
-  end
-
-  context 'for 32bit record data' do
-    let(:ip) { '1.0.16.1' }
-
-    it 'finds data' do
-      expect(rec32_db.lookup(ip)).to be_found
-    end
-  end
-
-  context 'test ips' do
-    [
-      ['185.23.124.1', 'SA'],
-      ['178.72.254.1', 'CZ'],
-      ['95.153.177.210', 'RU'],
-      ['200.148.105.119', 'BR'],
-      ['195.59.71.43', 'GB'],
-      ['179.175.47.87', 'BR'],
-      ['202.67.40.50', 'ID'],
-    ].each do |ip, iso|
-      it 'returns a MaxMindDB::Result' do
-        expect(city_db.lookup(ip)).to be_kind_of(MaxMindDB::Result)
-      end
-
-      it "returns #{iso} as the country iso code" do
-        expect(country_db.lookup(ip).country.iso_code).to eq(iso)
-      end
-    end
-  end
-
-  context 'test boolean data' do
-    let(:ip) { '41.194.0.1' }
-
-    it 'returns true for the is_satellite_provider trait' do
-      expect(city_db.lookup(ip).traits.is_satellite_provider).to eq(nil)
-    end
-
-    # There are no false booleans in the database that we can test.
-    # False values are simply omitted.
   end
 end
 


### PR DESCRIPTION
This PR attempts to address the issues raised in https://github.com/yhirose/maxminddb/pull/38.

Instead of defaulting to the low-memory reader, default to the previous `File.binread` reader. 

It seems the low-memory version takes a substantial performance hit to `lookup` times. Additionally, while thread safe, it's not safe across processes. That behavior may be surprising to some users.

I think `IO.pread` can be used to provide process safety. Unfortunately it's only available in ruby core after `2.5.0`: https://ruby-doc.org/core-2.5.0/IO.html#method-i-pread.

⚠️ This diff is easier to read without whitespace changes! https://github.com/yhirose/maxminddb/pull/44/files?w=1