### PR TITLE
Remove post-install message

### DIFF
--- a/maxminddb.gemspec
+++ b/maxminddb.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/yhirose/maxminddb"
   spec.license       = "MIT"
 
-  spec.post_install_message = "MIT"
-
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
This happens when bundling during a Heroku deploy:

```
remote:        Post-install message from maxminddb:
remote:        MIT
```

I'm assuming it's unintentional :)