### PR TITLE
Result includes 'network'

### DIFF
--- a/lib/maxminddb/result.rb
+++ b/lib/maxminddb/result.rb
@@ -57,6 +57,10 @@ module MaxMindDB
     def connection_type
       @_connection_type ||= raw['connection_type']
     end
+    
+    def network
+      @_network ||= raw['network']
+    end
 
     def to_hash
       @_to_hash ||= raw.clone

--- a/spec/maxminddb_spec.rb
+++ b/spec/maxminddb_spec.rb
@@ -46,6 +46,10 @@ describe MaxMindDB do
         it 'returns US as the country iso code' do
           expect(country_db.lookup(ip).country.iso_code).to eq('US')
         end
+        
+        it 'returns 74.125.192.0/18 as network' do 
+          expect(country_db.lookup(ip).network).to eq('74.125.192.0/18')
+        end
 
         context 'as a Integer' do
           let(:integer_ip) { IPAddr.new(ip).to_i }
@@ -77,6 +81,10 @@ describe MaxMindDB do
 
         it 'returns FI as the country iso code' do
           expect(country_db.lookup(ip).country.iso_code).to eq('FI')
+        end
+        
+        it 'returns 2001:708::/32 as network' do 
+          expect(country_db.lookup(ip).network).to eq('2001:708::/32')
         end
 
         context 'as an integer' do


### PR DESCRIPTION
When querying maxminddb ip are matched to a network. Here we add the matched maxminddb network (CIDR format) to the MaxMindDB::Result. 

for example: 
lookup "2001:708:510:8:9a6:442c:f8e0:7133" now returns "network"=>"2001:708::/32" too. 