### PR TITLE
Prefer the IPv4-Mapped IPv6 Address

### DIFF
--- a/lib/maxminddb.rb
+++ b/lib/maxminddb.rb
@@ -184,7 +184,7 @@ module MaxMindDB
       return ip_or_hostname if RUBY_VERSION.to_f >= 2.4 && klass == Integer
 
       addr = IPAddr.new(ip_or_hostname)
-      addr = addr.ipv4_compat if addr.ipv4?
+      addr = addr.ipv4_mapped if addr.ipv4?
       addr.to_i
     end
 


### PR DESCRIPTION
  - This form is not deprecated
  - Ruby commit which deprecated the method, in 2017
    https://github.com/ruby/ipaddr/commit/f8dbb6a2dc780195bf61e896980aa839c0457d31
  - https://tools.ietf.org/html/rfc4291#section-2.5.5.1
    RFC section on the deprecated form

---

I had no way of running the tests locally, so I offer this as an attempt.