### PR TITLE
CI: Add Ruby 3.0 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 rvm:
-- 2.4
-- 2.5
-- 2.6
-- 2.7
+- "2.4"
+- "2.5"
+- "2.6"
+- "2.7"
+- "3.0"
 script: bundle exec rake
 before_install:
 - gem update bundler


### PR DESCRIPTION
This uses the String form of the Float, in order for 3.0 not turning into the String "3".