### PR TITLE
gemspec: Drop unused directives

### DIFF
--- a/maxminddb.gemspec
+++ b/maxminddb.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
This PR removes the unused test_files directive and this gem exposes 0 executables, so we can remove that directive, too.